### PR TITLE
Fix null camera in build 98

### DIFF
--- a/CameraManager/AmalgamCamera.cs
+++ b/CameraManager/AmalgamCamera.cs
@@ -28,7 +28,12 @@ public class AmalgamCamera : MonoBehaviour
 
 		if ((cameraTypes & CameraType.World) > 0)
 		{
-			Camera? camera = CloneCamera(CameraAPI.GetCamera(CameraType.World), "AmalgamCamera (World)");
+			Camera? camera = null;
+			try
+			{
+				camera = CloneCamera(CameraAPI.GetCamera(CameraType.World), "AmalgamCamera (World)");
+			}
+			catch {}
 			if (camera == null)
 			{
 				Main.LogWarning($"Couldn't find {CameraType.World} camera.");
@@ -38,7 +43,12 @@ public class AmalgamCamera : MonoBehaviour
 
 		if ((cameraTypes & CameraType.UI) > 0)
 		{
-			Camera? camera = CloneCamera(CameraAPI.GetCamera(CameraType.UI), "AmalgamCamera (UI)");
+			Camera? camera = null;
+			try
+			{
+				camera = CloneCamera(CameraAPI.GetCamera(CameraType.UI), "AmalgamCamera (UI)");
+			}
+			catch {}
 			if (camera == null)
 			{
 				Main.LogWarning($"Couldn't find {CameraType.UI} camera.");
@@ -48,7 +58,12 @@ public class AmalgamCamera : MonoBehaviour
 
 		if ((cameraTypes & CameraType.Effects) > 0)
 		{
-			Camera? camera = CloneCamera(CameraAPI.GetCamera(CameraType.Effects), "AmalgamCamera (Effects)");
+			Camera? camera = null;
+			try
+			{
+				camera = CloneCamera(CameraAPI.GetCamera(CameraType.Effects), "AmalgamCamera (Effects)");
+			}
+			catch {}
 			if (camera == null)
 			{
 				Main.LogWarning($"Couldn't find {CameraType.Effects} camera.");

--- a/CameraManager/AmalgamCamera.cs
+++ b/CameraManager/AmalgamCamera.cs
@@ -56,21 +56,6 @@ public class AmalgamCamera : MonoBehaviour
 			else { cameras.Add(CameraType.UI, camera); }
 		}
 
-		if ((cameraTypes & CameraType.Effects) > 0)
-		{
-			Camera? camera = null;
-			try
-			{
-				camera = CloneCamera(CameraAPI.GetCamera(CameraType.Effects), "AmalgamCamera (Effects)");
-			}
-			catch {}
-			if (camera == null)
-			{
-				Main.LogWarning($"Couldn't find {CameraType.Effects} camera.");
-			}
-			else { cameras.Add(CameraType.Effects, camera); }
-		}
-
 		foreach ((_, Camera camera) in cameras)
 		{
 			if (camera == null) { continue; }

--- a/CameraManager/CameraAPI.cs
+++ b/CameraManager/CameraAPI.cs
@@ -7,13 +7,24 @@ namespace CameraManager;
 
 public static class CameraAPI
 {
-	public static Camera GetCamera(CameraType type) => type switch
+	public static Camera GetCamera(CameraType type)
 	{
-		CameraType.World => PlayerManager.PlayerCamera,
-		CameraType.UI => new List<Camera>(Camera.allCameras).Find(cam => cam.name == "SecondCamera"),
-		CameraType.Effects => new List<Camera>(Camera.allCameras).Find(cam => cam.name == "ThirdCamera"),
-		_ => throw new ArgumentOutOfRangeException(nameof(type), $"Unexpected camera type: {type}"),
-	};
+		Camera? camera = type switch
+		{
+			CameraType.World => PlayerManager.PlayerCamera,
+			CameraType.UI => new List<Camera>(Camera.allCameras).Find(cam => cam.name == "SecondCamera"),
+			CameraType.Effects => new List<Camera>(Camera.allCameras).Find(cam => cam.name == "ThirdCamera"),
+			_ => throw new ArgumentOutOfRangeException(nameof(type), $"Unexpected camera type: {type}"),
+		};
+
+		if (camera == null)
+		{
+			Main.LogError($"Couldn't find the {type} camera!\nAvailable cameras:\n[\n\t{string.Join<Camera>(",\n\t", Camera.allCameras)}\n]");
+			throw new NullReferenceException($"[CameraAPI] Couldn't find the {type} camera");
+		}
+
+		return camera;
+	}
 
 	public static Camera CloneCamera(Camera source)
 	{
@@ -24,7 +35,13 @@ public static class CameraAPI
 		// The player camera has child objects that we don't need
 		for (int i = gameObject.transform.childCount; i > 0; --i)
 		{
-			Destroy(gameObject.transform.GetChild(i - 1).gameObject);
+			Transform? child = gameObject.transform.GetChild(i - 1);
+			if (child?.gameObject == null)
+			{
+				Main.LogWarning($"Skipping unexpectedly null child game object for {source}.");
+				continue;
+			}
+			Destroy(child.gameObject);
 		}
 
 		return gameObject.GetComponent<Camera>();

--- a/CameraManager/CameraAPI.cs
+++ b/CameraManager/CameraAPI.cs
@@ -13,7 +13,6 @@ public static class CameraAPI
 		{
 			CameraType.World => PlayerManager.PlayerCamera,
 			CameraType.UI => new List<Camera>(Camera.allCameras).Find(cam => cam.name == "SecondCamera"),
-			CameraType.Effects => new List<Camera>(Camera.allCameras).Find(cam => cam.name == "ThirdCamera"),
 			_ => throw new ArgumentOutOfRangeException(nameof(type), $"Unexpected camera type: {type}"),
 		};
 

--- a/CameraManager/CameraType.cs
+++ b/CameraManager/CameraType.cs
@@ -3,11 +3,9 @@ namespace CameraManager;
 // Derail Valley uses 3 cameras
 //   1. Camera (eye) - renders most things in the world, depth 0 (Layers 267386643)
 //   2. SecondCamera - renders UI, depth 1 (Layer 32)
-//   3. ThridCamera  - renders effects, depth 2 (Layer 4)
 public enum CameraType
 {
 	World = 1,
 	UI = 2,
-	Effects = 4,
-	All = 7,
+	All = 3,
 }


### PR DESCRIPTION
The effects camera (a.k.a. `ThirdCamera`) was removed from the base game. Effects appear to be applied directly to the world camera now.